### PR TITLE
Change API for flexibility and clarity

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,7 @@
 import {excludeDuplicatePatterns, patternToRegex} from 'webext-patterns';
 
-export async function getManifestPermissions(): Promise<
-Required<chrome.permissions.Permissions>
-> {
-	return getManifestPermissionsSync();
-}
-
-export function getManifestPermissionsSync(): Required<chrome.permissions.Permissions> {
-	return _getManifestPermissionsSync(chrome.runtime.getManifest());
-}
-
-export function _getManifestPermissionsSync(
-	manifest: chrome.runtime.Manifest,
+export function normalizeManifestPermissions(
+	manifest = chrome.runtime.getManifest(),
 ): Required<chrome.permissions.Permissions> {
 	const manifestPermissions: Required<chrome.permissions.Permissions> = {
 		origins: [],
@@ -63,7 +53,7 @@ export function selectAdditionalPermissionsSync(
 	permissions: chrome.permissions.Permissions,
 	options?: Options,
 ): Required<chrome.permissions.Permissions> {
-	const manifestPermissions = getManifestPermissionsSync();
+	const manifestPermissions = normalizeManifestPermissions();
 	return _getAdditionalPermissions(manifestPermissions, permissions, options);
 }
 
@@ -72,7 +62,7 @@ export async function getAdditionalPermissions(
 ): Promise<Required<chrome.permissions.Permissions>> {
 	return new Promise(resolve => {
 		chrome.permissions.getAll(currentPermissions => {
-			const manifestPermissions = getManifestPermissionsSync();
+			const manifestPermissions = normalizeManifestPermissions();
 			resolve(
 				_getAdditionalPermissions(
 					manifestPermissions,
@@ -129,7 +119,7 @@ export function _isUrlPermittedByManifest(
 	origin: string,
 	manifest: chrome.runtime.Manifest,
 ): boolean {
-	const manifestPermissions = _getManifestPermissionsSync(manifest);
+	const manifestPermissions = normalizeManifestPermissions(manifest);
 	const originsRegex = patternToRegex(...manifestPermissions.origins);
 	return originsRegex.test(origin);
 }

--- a/index.ts
+++ b/index.ts
@@ -98,13 +98,9 @@ export function extractAdditionalPermissions(
 	return additionalPermissions;
 }
 
-export function isUrlPermittedByManifest(origin: string): boolean {
-	return _isUrlPermittedByManifest(origin, chrome.runtime.getManifest());
-}
-
-export function _isUrlPermittedByManifest(
+export function isUrlPermittedByManifest(
 	origin: string,
-	manifest: chrome.runtime.Manifest,
+	manifest = chrome.runtime.getManifest(),
 ): boolean {
 	const manifestPermissions = normalizeManifestPermissions(manifest);
 	const originsRegex = patternToRegex(...manifestPermissions.origins);

--- a/readme.md
+++ b/readme.md
@@ -156,12 +156,19 @@ This function accepts a [`Permissions`](https://developer.mozilla.org/en-US/docs
 
 You can alternatively use the underlying [`excludeDuplicatePatterns` in `webext-patterns`](https://github.com/fregante/webext-patterns#excludeduplicatepatternspattern1-pattern2-etc) if you want to use raw arrays of origins.
 
-### isUrlPermittedByManifest(url)
+### isUrlPermittedByManifest(url, manifest)
 
 Check whether a specific URL is statically permitted by the manifest, whether in the `permissions` array or in a content script. Like `chrome.permissions.contains` except:
 
 - it's synchronous
 - it's only `true` if the URL is in the manifest (additional permissions are not taken into consideration)
+
+#### manifest
+
+Type: `object`
+Default: `chrome.runtime.getManifest()`
+
+The whole `manifest.json` object to be parsed. By default it asks the browser to provide it.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ npm install -D @types/chrome
 // This module is only offered as a ES Module
 import {
 	getAdditionalPermissions,
-	getManifestPermissions,
+	normalizeManifestPermissions,
 } from 'webext-permissions';
 ```
 
@@ -54,7 +54,7 @@ Simple example with the above manifest:
 	const newPermissions = await getAdditionalPermissions();
 	// => {origins: [], permissions: []}
 
-	const manifestPermissions = await getManifestPermissions();
+	const manifestPermissions = await normalizeManifestPermissions();
 	// => {origins: ['https://google.com/*'], permissions: ['storage']}
 })();
 ```
@@ -74,7 +74,7 @@ async function onGrantPermissionButtonClick() {
 	// => {origins: ['https://facebook.com/*'], permissions: []}
 
 	// This module: the manifest permissions are unchanged
-	const manifestPermissions = await getManifestPermissions();
+	const manifestPermissions = await normalizeManifestPermissions();
 	// => {origins: ['https://google.com/*'], permissions: ['storage']}
 }
 ```
@@ -116,12 +116,13 @@ Same as [getAdditionalPermissions](#getadditionalpermissionsoptions).
 
 Same as `selectAdditionalPermissions` but it doesn't return a Promise.
 
-### getManifestPermissions()
+### normalizeManifestPermissions(manifest)
 
-Returns a promise that resolves with a [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions) object listing the permissions inferred from the manifest file.
+Returns a [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions) object listing the permissions inferred from the manifest file.
 
 Differences from `chrome.runtime.getManifest().permissions`:
 
+- this function always returns a `{origin, permissions}` object rather than a flat `permissions` array, even in MV3
 - this function also includes host permissions inferred from all the content scripts
 - this function also includes the `devtools` permission inferred from the `devtools_page`, if present
 
@@ -129,9 +130,12 @@ Difference from `chrome.permissions.getAll`:
 
 - this function only includes the permissions you declared in `manifest.json`.
 
-### getManifestPermissionsSync()
+#### manifest
 
-Same as `getManifestPermissions` but it doesn't return a Promise.
+Type: `object`
+Default: chrome.runtime.getManifest()
+
+The whole `manifest.json` object to be parsed. By default it asks the browser to provide it.
 
 ### dropOverlappingPermissions(permissions)
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ npm install -D @types/chrome
 ```js
 // This module is only offered as a ES Module
 import {
-	getAdditionalPermissions,
+	queryAdditionalPermissions,
 	normalizeManifestPermissions,
 } from 'webext-permissions';
 ```
@@ -51,7 +51,7 @@ Simple example with the above manifest:
 
 ```js
 (async () => {
-	const newPermissions = await getAdditionalPermissions();
+	const newPermissions = await queryAdditionalPermissions();
 	// => {origins: [], permissions: []}
 
 	const manifestPermissions = await normalizeManifestPermissions();
@@ -70,7 +70,7 @@ async function onGrantPermissionButtonClick() {
 	// => {origins: ['https://google.com/*', 'https://facebook.com/*'], permissions: ['storage']}
 
 	// This module: only the new permission is returned
-	const newPermissions = await getAdditionalPermissions();
+	const newPermissions = await queryAdditionalPermissions();
 	// => {origins: ['https://facebook.com/*'], permissions: []}
 
 	// This module: the manifest permissions are unchanged
@@ -81,7 +81,7 @@ async function onGrantPermissionButtonClick() {
 
 ## API
 
-### getAdditionalPermissions(options)
+### queryAdditionalPermissions(options)
 
 Returns a promise that resolves with a [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions) object like `chrome.permissions.getAll` and `browser.permissions.getAll`, but only includes the optional permissions that the user granted you.
 
@@ -98,9 +98,12 @@ If the manifest contains the permission `https://github.com/*` and then you requ
 
 If this distinction doesn't matter for you (for example if the protocol is always `https` and there are no subdomains), you can use `strictOrigins: false`, so that the requested permission will not be reported as _additional_.
 
-### selectAdditionalPermissions(permissions, options)
+### extractAdditionalPermissions(currentPermissions, options)
 
-Like `getAdditionalPermissions`, but instead of querying the current permissions, you can pass a [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions) object.
+
+Like `queryAdditionalPermissions`, but instead of querying the current permissions, you can pass a [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions) object.
+
+This function returns synchronously.
 
 #### permissions
 
@@ -110,11 +113,19 @@ Type: [`Permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/W
 
 Type: `object`
 
-Same as [getAdditionalPermissions](#getadditionalpermissionsoptions).
+##### strictOrigins
 
-### selectAdditionalPermissionsSync(permissions, options)
+Type: `boolean`\
+Default: `true`
 
-Same as `selectAdditionalPermissions` but it doesn't return a Promise.
+See [strictOrigins](#strictorigins) above
+
+##### manifest
+
+Type: `object`
+Default: `chrome.runtime.getManifest()`
+
+The whole `manifest.json` object to be parsed. By default it asks the browser to provide it.
 
 ### normalizeManifestPermissions(manifest)
 
@@ -133,7 +144,7 @@ Difference from `chrome.permissions.getAll`:
 #### manifest
 
 Type: `object`
-Default: chrome.runtime.getManifest()
+Default: `chrome.runtime.getManifest()`
 
 The whole `manifest.json` object to be parsed. By default it asks the browser to provide it.
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,8 @@ import {readFileSync} from 'node:fs';
 import test from 'ava';
 import {
 	normalizeManifestPermissions,
-	_getAdditionalPermissions,
-	_isUrlPermittedByManifest,
+	extractAdditionalPermissions,
+	isUrlPermittedByManifest,
 	dropOverlappingPermissions,
 } from '../index.js';
 
@@ -31,17 +31,15 @@ test('normalizeManifestPermissions', t => {
 	});
 });
 
-test('queryAdditionalPermissions at install', t => {
-	const manifestPermissions = normalizeManifestPermissions(manifest);
-	t.deepEqual(_getAdditionalPermissions(manifestPermissions, atStart), {
+test('extractAdditionalPermissions at install', t => {
+	t.deepEqual(extractAdditionalPermissions(atStart, {manifest}), {
 		origins: [],
 		permissions: [],
 	});
 });
 
-test('queryAdditionalPermissions after added permissions', t => {
-	const manifestPermissions = normalizeManifestPermissions(manifest);
-	t.deepEqual(_getAdditionalPermissions(manifestPermissions, afterAddition), {
+test('extractAdditionalPermissions after added permissions', t => {
+	t.deepEqual(extractAdditionalPermissions(afterAddition, {manifest}), {
 		origins: [
 			'https://*.github.com/*',
 			'https://git.example.com/*',
@@ -52,9 +50,8 @@ test('queryAdditionalPermissions after added permissions', t => {
 	});
 });
 
-test('queryAdditionalPermissions after added permissions, loose origin check', t => {
-	const manifestPermissions = normalizeManifestPermissions(manifest);
-	t.deepEqual(_getAdditionalPermissions(manifestPermissions,	afterAddition,	{strictOrigins: false}), {
+test('extractAdditionalPermissions after added permissions, loose origin check', t => {
+	t.deepEqual(extractAdditionalPermissions(afterAddition, {manifest, strictOrigins: false}), {
 		origins: [
 			'https://git.example.com/*',
 		],
@@ -134,10 +131,10 @@ test('extractAdditionalPermissions', t => {
 
 test('isUrlPermittedByManifest ', t => {
 	/* eslint-disable camelcase */
-	t.is(_isUrlPermittedByManifest('https://ghe.github.com/*', manifest), true);
-	t.is(_isUrlPermittedByManifest('https://github.com/contacts/', manifest), true);
-	t.is(_isUrlPermittedByManifest('https://other.github.com/contacts/', manifest), false);
-	t.is(_isUrlPermittedByManifest('https://example.com/contacts/', {
+	t.is(isUrlPermittedByManifest('https://ghe.github.com/*', manifest), true);
+	t.is(isUrlPermittedByManifest('https://github.com/contacts/', manifest), true);
+	t.is(isUrlPermittedByManifest('https://other.github.com/contacts/', manifest), false);
+	t.is(isUrlPermittedByManifest('https://example.com/contacts/', {
 		content_scripts: [
 			{
 				matches: [
@@ -146,7 +143,7 @@ test('isUrlPermittedByManifest ', t => {
 			},
 		],
 	}), true);
-	t.is(_isUrlPermittedByManifest('http://insecure.com/', {
+	t.is(isUrlPermittedByManifest('http://insecure.com/', {
 		content_scripts: [
 			{
 				matches: [

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import {readFileSync} from 'node:fs';
 import test from 'ava';
 import {
-	_getManifestPermissionsSync,
+	normalizeManifestPermissions,
 	_getAdditionalPermissions,
 	_isUrlPermittedByManifest,
 	dropOverlappingPermissions,
@@ -13,8 +13,8 @@ const manifest = readJson('./fixtures/manifest.json');
 const atStart = readJson('./fixtures/reported-at-start.json');
 const afterAddition = readJson('./fixtures/reported-after-addition.json');
 
-test('getManifestPermissions', t => {
-	t.deepEqual(_getManifestPermissionsSync(manifest), {
+test('normalizeManifestPermissions', t => {
+	t.deepEqual(normalizeManifestPermissions(manifest), {
 		origins: [
 			'https://github.com/*',
 			'https://api.github.com/*',
@@ -32,7 +32,7 @@ test('getManifestPermissions', t => {
 });
 
 test('getAdditionalPermissions at install', t => {
-	const manifestPermissions = _getManifestPermissionsSync(manifest);
+	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions, atStart), {
 		origins: [],
 		permissions: [],
@@ -40,7 +40,7 @@ test('getAdditionalPermissions at install', t => {
 });
 
 test('getAdditionalPermissions after added permissions', t => {
-	const manifestPermissions = _getManifestPermissionsSync(manifest);
+	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions, afterAddition), {
 		origins: [
 			'https://*.github.com/*',
@@ -53,7 +53,7 @@ test('getAdditionalPermissions after added permissions', t => {
 });
 
 test('getAdditionalPermissions after added permissions, loose origin check', t => {
-	const manifestPermissions = _getManifestPermissionsSync(manifest);
+	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions,	afterAddition,	{strictOrigins: false}), {
 		origins: [
 			'https://git.example.com/*',
@@ -127,7 +127,7 @@ test('dropOverlappingPermissions', t => {
 	}, 'A pathname star should drop all other same-origin origins');
 });
 
-// This is identical to the internal _getManifestPermissionsSync, which is already tested
+// This is identical to the internal normalizeManifestPermissions, which is already tested
 test('selectAdditionalPermissions', t => {
 	t.pass();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -31,7 +31,7 @@ test('normalizeManifestPermissions', t => {
 	});
 });
 
-test('getAdditionalPermissions at install', t => {
+test('queryAdditionalPermissions at install', t => {
 	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions, atStart), {
 		origins: [],
@@ -39,7 +39,7 @@ test('getAdditionalPermissions at install', t => {
 	});
 });
 
-test('getAdditionalPermissions after added permissions', t => {
+test('queryAdditionalPermissions after added permissions', t => {
 	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions, afterAddition), {
 		origins: [
@@ -52,7 +52,7 @@ test('getAdditionalPermissions after added permissions', t => {
 	});
 });
 
-test('getAdditionalPermissions after added permissions, loose origin check', t => {
+test('queryAdditionalPermissions after added permissions, loose origin check', t => {
 	const manifestPermissions = normalizeManifestPermissions(manifest);
 	t.deepEqual(_getAdditionalPermissions(manifestPermissions,	afterAddition,	{strictOrigins: false}), {
 		origins: [
@@ -128,7 +128,7 @@ test('dropOverlappingPermissions', t => {
 });
 
 // This is identical to the internal normalizeManifestPermissions, which is already tested
-test('selectAdditionalPermissions', t => {
+test('extractAdditionalPermissions', t => {
 	t.pass();
 });
 


### PR DESCRIPTION
```diff
- getManifestPermissions()
- getManifestPermissionsSync()
- _getManifestPermissionsSync()
+ normalizeManifestPermissions(): Sync function that optionally takes a `manifest` object

- selectAdditionalPermissions()
- selectAdditionalPermissionsSync()
+ extractAdditionalPermissions(): Sync function that optionally takes a `manifest` object

- getAdditionalPermissions()
+ queryAdditionalPermissions(): Same, clearer name

isUrlPermittedByManifest: Now it optionally takes a `manifest` object
```
