### PR TITLE
Exclude overlapping hosts when normalizing

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -28,7 +28,7 @@ describe.each([
 		t.deepEqual(normalizeManifestPermissions(manifest), {
 			origins: [
 				'https://github.com/*',
-				'https://api.github.com/*',
+				'*://api.github.com/*',
 				'https://gist.github.com/*',
 				'https://ghe.github.com/*',
 			],
@@ -84,6 +84,7 @@ describe.each([
 			origins: [
 				'<all_urls>',
 			],
+			permissions: [],
 		}, '<all_urls> should catch all');
 
 		t.deepEqual(dropOverlappingPermissions({
@@ -94,6 +95,7 @@ describe.each([
 			],
 		}), {
 			origins: ['*://*/*'],
+			permissions: [],
 		}, '*://*/* should catch all');
 
 		t.deepEqual(dropOverlappingPermissions({
@@ -107,6 +109,7 @@ describe.each([
 				'http://*.example.com/*',
 				'https://*/*',
 			],
+			permissions: [],
 		}, 'https://*/* should drop all other https origins');
 
 		t.deepEqual(dropOverlappingPermissions({
@@ -121,6 +124,7 @@ describe.each([
 				'https://*.example.com/*',
 				'https://fregante.com/*',
 			],
+			permissions: [],
 		}, 'A subdomain star should drop all other same-domain origins');
 
 		t.deepEqual(dropOverlappingPermissions({
@@ -132,6 +136,7 @@ describe.each([
 			origins: [
 				'https://git.example.com/*',
 			],
+			permissions: [],
 		}, 'A pathname star should drop all other same-origin origins');
 	});
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -32,7 +32,7 @@ export function normalizeManifestPermissions(
 		}
 	}
 
-	return manifestPermissions;
+	return dropOverlappingPermissions(manifestPermissions);
 }
 
 type OriginsOptions = {
@@ -109,15 +109,9 @@ export function isUrlPermittedByManifest(
 	return originsRegex.test(origin);
 }
 
-export function dropOverlappingPermissions({origins, permissions}: chrome.permissions.Permissions): chrome.permissions.Permissions {
-	const result: chrome.permissions.Permissions = {};
-	if (origins) {
-		result.origins = excludeDuplicatePatterns(origins);
-	}
-
-	if (permissions) {
-		result.permissions = [...permissions];
-	}
-
-	return result;
+export function dropOverlappingPermissions({origins, permissions}: chrome.permissions.Permissions): Required<chrome.permissions.Permissions> {
+	return {
+		origins: origins ? excludeDuplicatePatterns(origins) : [],
+		permissions: permissions ? [...permissions] : [],
+	};
 }

--- a/test-fixtures/manifest-v2.json
+++ b/test-fixtures/manifest-v2.json
@@ -9,7 +9,8 @@
 		"activeTab",
 		"alarms",
 		"https://github.com/*",
-		"https://api.github.com/*"
+		"https://api.github.com/*",
+		"*://api.github.com/*"
 	],
 	"content_scripts": [
 		{

--- a/test-fixtures/manifest-v3.json
+++ b/test-fixtures/manifest-v3.json
@@ -11,7 +11,8 @@
 	],
 	"host_permissions": [
 		"https://github.com/*",
-		"https://api.github.com/*"
+		"https://api.github.com/*",
+		"*://api.github.com/*"
 	],
 	"content_scripts": [
 		{

--- a/test-fixtures/reported-after-addition.json
+++ b/test-fixtures/reported-after-addition.json
@@ -1,6 +1,6 @@
 {
 	"origins": [
-		"https://api.github.com/*",
+		"*://api.github.com/*",
 		"https://gist.github.com/*",
 		"https://github.com/*",
 		"https://*.github.com/*",

--- a/test-fixtures/reported-at-start.json
+++ b/test-fixtures/reported-at-start.json
@@ -1,6 +1,6 @@
 {
 	"origins": [
-		"https://api.github.com/*",
+		"*://api.github.com/*",
 		"https://gist.github.com/*",
 		"https://github.com/*"
 	],


### PR DESCRIPTION
I think it makes sense to automatically drop overlapping permissions when "normalizing" the manifest.