### PR TITLE
`isUrlPermittedByManifest` - Add tests for subdomain wildcard

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -55,11 +55,6 @@ describe.each([
 			origins: [
 				'https://*.github.com/*',
 				'https://git.example.com/*',
-				// According to the documentation, strictOrigins is only concerned
-				// with widening of permissions, not narrowing.  Therefore
-				// This should exclude https://subdomain.hassubdomains.com/*
-				// because it's not an additional permission relative to
-				// https://*.hassubdomains.com/* which is already in the manifest.
 			],
 			permissions: [
 				'someOtherPermission',

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -29,6 +29,7 @@ describe.each([
 			origins: [
 				'https://github.com/*',
 				'*://api.github.com/*',
+				'https://*.hassubdomains.com/*',
 				'https://gist.github.com/*',
 				'https://ghe.github.com/*',
 			],
@@ -167,6 +168,10 @@ describe.each([
 				},
 			],
 		} as chrome.runtime.Manifest), false);
+		t.is(isUrlPermittedByManifest('https://hassubdomains.com/', manifest), true);
+		t.is(isUrlPermittedByManifest('https://hassubdomains.com/foo/', manifest), true);
+		t.is(isUrlPermittedByManifest('https://subdomain.hassubdomains.com/', manifest), true);
+		t.is(isUrlPermittedByManifest('https://subdomain.hassubdomains.com/foo/', manifest), true);
 	});
 },
 );

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -55,6 +55,11 @@ describe.each([
 			origins: [
 				'https://*.github.com/*',
 				'https://git.example.com/*',
+				// According to the documentation, strictOrigins is only concerned
+				// with widening of permissions, not narrowing.  Therefore
+				// This should exclude https://subdomain.hassubdomains.com/*
+				// because it's not an additional permission relative to
+				// https://*.hassubdomains.com/* which is already in the manifest.
 			],
 			permissions: [
 				'someOtherPermission',

--- a/test-fixtures/manifest-v2.json
+++ b/test-fixtures/manifest-v2.json
@@ -10,7 +10,8 @@
 		"alarms",
 		"https://github.com/*",
 		"https://api.github.com/*",
-		"*://api.github.com/*"
+		"*://api.github.com/*",
+		"https://*.hassubdomains.com/*"
 	],
 	"content_scripts": [
 		{

--- a/test-fixtures/manifest-v3.json
+++ b/test-fixtures/manifest-v3.json
@@ -12,7 +12,8 @@
 	"host_permissions": [
 		"https://github.com/*",
 		"https://api.github.com/*",
-		"*://api.github.com/*"
+		"*://api.github.com/*",
+		"https://*.hassubdomains.com/*"
 	],
 	"content_scripts": [
 		{

--- a/test-fixtures/reported-after-addition.json
+++ b/test-fixtures/reported-after-addition.json
@@ -5,7 +5,8 @@
 		"https://github.com/*",
 		"https://*.hassubdomains.com/*",
 		"https://*.github.com/*",
-		"https://git.example.com/*"
+		"https://git.example.com/*",
+		"https://subdomain.hassubdomains.com/*"
 	],
 	"permissions": [
 		"activeTab",

--- a/test-fixtures/reported-after-addition.json
+++ b/test-fixtures/reported-after-addition.json
@@ -3,6 +3,7 @@
 		"*://api.github.com/*",
 		"https://gist.github.com/*",
 		"https://github.com/*",
+		"https://*.hassubdomains.com/*",
 		"https://*.github.com/*",
 		"https://git.example.com/*"
 	],

--- a/test-fixtures/reported-after-addition.json
+++ b/test-fixtures/reported-after-addition.json
@@ -5,8 +5,7 @@
 		"https://github.com/*",
 		"https://*.hassubdomains.com/*",
 		"https://*.github.com/*",
-		"https://git.example.com/*",
-		"https://subdomain.hassubdomains.com/*"
+		"https://git.example.com/*"
 	],
 	"permissions": [
 		"activeTab",

--- a/test-fixtures/reported-at-start.json
+++ b/test-fixtures/reported-at-start.json
@@ -2,7 +2,8 @@
 	"origins": [
 		"*://api.github.com/*",
 		"https://gist.github.com/*",
-		"https://github.com/*"
+		"https://github.com/*",
+		"https://*.hassubdomains.com/*"
 	],
 	"permissions": [
 		"activeTab",


### PR DESCRIPTION
Add `https://*.hassubdomains.com/*` to the test manifests, to prove that subdomain matching is already working correctly, and allow for other tests relating to subdomains (see #23).